### PR TITLE
ruck/stages/disk.py: remove option --offline from systemd-repart

### DIFF
--- a/ruck/stages/disk.py
+++ b/ruck/stages/disk.py
@@ -65,7 +65,6 @@ class DiskPlugin(Base):
             "--size", size,
             "--dry-run=no",
             "--discard=no",
-            "--offline=true",
             "--no-pager",
             str(image)],
             cwd=self.workspace)


### PR DESCRIPTION
On debian 12 (bookworm), the version of systemd-repart is 252 which does not support option --offline

$ cat /etc/issue
Debian GNU/Linux 12 \n \l

$ systemd-repart --version
systemd 252 (252.22-1~deb12u1)

According to [1],  Option --offline is added in version 254.

Remove it from systemd-repart

[1] https://www.freedesktop.org/software/systemd/man/latest/systemd-repart.html#--offline=BOOL