### PR TITLE
ruck/stages/ostree.py: create archive ostree repository for network

### DIFF
--- a/config/uefi-ostree/image.yaml
+++ b/config/uefi-ostree/image.yaml
@@ -16,7 +16,7 @@ steps:
   - step: ostree_init
     options:
       repo: /var/www/html/repo
-      mode: bare
+      mode: archive-z2
   - step: ostree_prep
     options:
       repo: /var/www/html/repo

--- a/ruck/stages/ostree.py
+++ b/ruck/stages/ostree.py
@@ -33,13 +33,14 @@ class OstreeBase(Base):
 
 class OstreeInitPlugin(OstreeBase):
     def run(self):
-        self.logging.info("Creating ostree repository.")
-
         repo = pathlib.Path(self.options.get("repo"))
+        mode = self.options.get("mode") or "archive-z2"
+
+        self.logging.info(f"Creating ostree repository {repo}, mode {mode}.")
 
         if not repo.exists():
             utils.run_command(
-                ["ostree", "init", "--repo", repo])
+                ["ostree", "init", "--repo", repo, "--mode", mode])
 
 
 class OstreeDeployPlugin(OstreeBase):


### PR DESCRIPTION
$ cd config/uefi-ostree
$ sudo ruck build --config image.yaml
...
2024-03-27 04:03:55,977 Creating ostree repository /var/www/html/repo, mode archive-z2. 2024-03-27 04:03:56,030 Creating ostree branch.
...

In order to support install from remote ostree repository, according to [1], create archive mode ostree repository to be served over the network.

[1] https://manpages.debian.org/testing/ostree/ostree-init.1.en.html